### PR TITLE
Add Ruby 3.2 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,9 @@ jobs:
           - 2.4
           - 2.5
           - 2.6
-          - 3.0
+          - '3.0'
           - 3.1
+          - 3.2
           - ruby-head
           - jruby-9.2.13.0
           - jruby-head
@@ -55,7 +56,7 @@ jobs:
       COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
### Describe the change

Adds Ruby 3.2 to the CI matrix.
Updates the checkout action version to v3
Quotes "3.0" in the CI configuration

Runs green on my fork.

### Why are we doing this?

Ruby 3.2 is a released major version, and the gem should be tested against it.
Updating the checkout action ensures that a supported version of Node is used in the specs, eliminating warnings.
Quoting "3.0" ensures that it is not truncated to "3", which is the current behavior.  Truncation causes it to load the latest Ruby 3 for this matrix entry, which is not the intended behavior.

### Benefits

Better compatibility guarantees with Ruby versions.  Fewer warnings.

### Drawbacks

None.

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [X] Tests written & passing locally?
- [X] Code style checked?
- [X] Rebased with `master` branch?
- [ ] Documentation updated?
- [ ] Changelog updated?
